### PR TITLE
Feature/consume result of query before returning

### DIFF
--- a/src/promg/database_managers/db_connection.py
+++ b/src/promg/database_managers/db_connection.py
@@ -1,5 +1,5 @@
 from string import Template
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Tuple
 
 import neo4j
 from neo4j import GraphDatabase
@@ -83,7 +83,7 @@ class DatabaseConnection:
         @return: The result of the query or None
         """
 
-        def run_query(tx: neo4j.Transaction, _query: str, **_kwargs) -> Optional[tuple[
+        def run_query(tx: neo4j.Transaction, _query: str, **_kwargs) -> Tuple[Optional[
             List[Dict[str, Any]], neo4j.ResultSummary]]:
 
             """

--- a/src/promg/database_managers/db_connection.py
+++ b/src/promg/database_managers/db_connection.py
@@ -1,7 +1,7 @@
 from string import Template
 from typing import Optional, List, Dict, Any, Tuple
 
-from neo4j import GraphDatabase
+import neo4j
 from ..utilities.configuration import Configuration
 
 
@@ -28,7 +28,7 @@ class DatabaseConnection:
     def start_connection(uri: str, user: str, password: str):
         # begin config
         # connection to Neo4J database
-        driver = GraphDatabase.driver(uri, auth=(user, password), max_connection_lifetime=200)
+        driver = neo4j.GraphDatabase.driver(uri, auth=(user, password), max_connection_lifetime=200)
         return driver
 
     def close_connection(self):

--- a/src/promg/database_managers/db_connection.py
+++ b/src/promg/database_managers/db_connection.py
@@ -83,8 +83,8 @@ class DatabaseConnection:
         @return: The result of the query or None
         """
 
-        def run_query(tx: neo4j.Transaction, _query: str, **_kwargs) -> Tuple[Optional[
-            List[Dict[str, Any]], neo4j.ResultSummary]]:
+        def run_query(tx: neo4j.Transaction, _query: str, **_kwargs) \
+                -> Tuple[Optional[List[Dict[str, Any]]], neo4j.ResultSummary]:
 
             """
                 Run the query and return the result of the query

--- a/src/promg/database_managers/db_connection.py
+++ b/src/promg/database_managers/db_connection.py
@@ -83,8 +83,8 @@ class DatabaseConnection:
         @return: The result of the query or None
         """
 
-        def run_query(tx: neo4j.Transaction, _query: str, **_kwargs) \
-                -> Tuple[Optional[List[Dict[str, Any]]], neo4j.ResultSummary]:
+        def run_query(tx: neo4j.Transaction, _query: str, **_kwargs) -> Tuple[
+            Optional[List[Dict[str, Any]]], neo4j.ResultSummary]:
 
             """
                 Run the query and return the result of the query
@@ -101,7 +101,8 @@ class DatabaseConnection:
                 self.close_connection()
                 print(inst)
             else:
-                if _result_records is not None and _result_records != []:  # return the values if result is not none or empty list
+                if _result_records is not None and _result_records != []:  # return the values if result is not none
+                    # or empty list
                     return _result_records, _summary
                 else:
                     return None, _summary


### PR DESCRIPTION
1) We consume the results to ensure it is exhausted.
2) Move the try/catch to the session.execute_write instead of around the tx.run(). 

> If the try/catch is around the tx.run(), we have the following issue:
> when a query fails (tx.run or an operation on _result) with a Neo4jError, this likely means that the transaction is broken beyond recovery. By swallowing the error, the driver will nevertheless try to commit the transaction. Depending on the driver version you'll get either the driver throw some exception (probably TransactionError) or a possibly harder to understand error from the server in such a case.

This advice was given to me on the Neo4j forum: https://community.neo4j.com/t/database-is-holding-onto-file-after-apoc-load-csv-creating-a-permission-error/67943