### PR TITLE
Feature/add properties to relationships in semantic header

### DIFF
--- a/src/promg/cypher_queries/semantic_header_ql.py
+++ b/src/promg/cypher_queries/semantic_header_ql.py
@@ -15,15 +15,12 @@ class SemanticHeaderQueryLibrary:
         # create a new entity node if it not exists yet with properties
         merge_or_create = 'MERGE' if merge else 'CREATE'
         set_label_str = ""
-        set_property_str = ""
+        set_property_str = node_constructor.get_set_result_properties_query()
         infer_corr_str = ""
         infer_observed_str = ""
 
         if node_constructor.set_labels is not None:
             set_label_str = f'SET $set_labels'''
-
-        if len(node_constructor.result.optional_properties) > 0:
-            set_property_str = 'SET $set_result_properties'
 
         if len(node_constructor.inferred_relationships) > 0:
             infer_corr_str = '''WITH record, $result_node_name'''
@@ -96,7 +93,6 @@ class SemanticHeaderQueryLibrary:
                      template_string_parameters={
                          "record": node_constructor.get_prevalent_record_pattern(node_name="record"),
                          "record_name": "record",
-                         "conditions": node_constructor.get_where_condition(node_name="record", include_start_and=True),
                          "result_node": node_constructor.result.get_pattern(),
                          "result_node_name": node_constructor.result.get_name(),
                          "set_result_properties": node_constructor.get_set_result_properties_query(),

--- a/src/promg/data_managers/properties.py
+++ b/src/promg/data_managers/properties.py
@@ -1,0 +1,116 @@
+from string import Template
+from typing import List, Optional
+
+
+class Property:
+    def __init__(self, attribute: str, value: str, node_name: Optional[str],
+                 node_attribute: Optional[str], ref_node: Optional[str], ref_attribute: Optional[str]):
+        self.attribute = attribute
+        self.value = value
+        self.node_name = node_name,
+        self.node_attribute = node_attribute,
+        self.ref_node = ref_node
+        self.ref_attribute = ref_attribute
+
+    @staticmethod
+    def from_string(property_description):
+        if property_description is None:
+            return None
+        if ":" in property_description:
+            components = property_description.split(":")
+        else:
+            components = property_description.split("=")
+        attribute = components[0]
+        value = components[1]
+        attribute = attribute.strip()
+        value = value.strip()
+
+        ref_node, ref_attribute, node_name, node_attribute = None, None, None, None
+        if "." in value:
+            components = value.split(".")
+            ref_node = components[0]
+            ref_attribute = components[1]
+
+        if "." in attribute:
+            components = attribute.split(".")
+            node_name = components[0]
+            node_attribute = components[1]
+
+        return Property(attribute=attribute, value=value, node_name=node_name,
+                        node_attribute=node_attribute, ref_node=ref_node, ref_attribute=ref_attribute)
+
+    def get_pattern(self, is_set=False, node_name=None):
+        if not is_set:
+            return f"{self.attribute}: {self.value}"
+        else:
+            if node_name is None:
+                return f"{self.attribute} = {self.value}"
+            else:
+                return f"{node_name}.{self.attribute} = COALESCE({node_name}.{self.attribute}, {self.value})"
+
+    def __repr__(self):
+        return self.get_pattern()
+
+
+class Properties:
+    def __init__(self, required_properties: List[Property], optional_properties: List[Property]):
+        self.required_properties = required_properties
+        self.optional_properties = optional_properties
+
+    @staticmethod
+    def from_string(properties_str: str):
+        """
+        Interpret properties as a string and return it as a Properties object.
+        :param properties_str:
+        :return:
+        """
+        if properties_str is None:
+            return None
+
+        properties_str = properties_str.replace("}", "")
+        properties = properties_str.split(",")
+
+        required_properties = [prop for prop in properties if "OPTIONAL" not in prop]
+        optional_properties = [prop.replace("OPTIONAL", "") for prop in properties if "OPTIONAL" in prop]
+
+        required_properties = [Property.from_string(prop) for prop in required_properties]
+        optional_properties = [Property.from_string(prop) for prop in optional_properties]
+
+        return Properties(
+            required_properties=required_properties,
+            optional_properties=optional_properties
+        )
+
+    def get_string(self, with_brackets=False, with_optional=False):
+        '''
+        Return a string representation of the properties
+        :param with_brackets:
+        :param with_optional:
+        :return:
+        '''
+        properties = [req_prop.get_pattern() for req_prop in self.required_properties]
+        if with_optional:
+            properties += [f"OPTIONAL {prop.get_pattern()}" for prop in self.optional_properties]
+
+        properties = ", ".join(properties)
+        if with_brackets:
+            property_string = "{$properties}"
+            properties = Template(property_string).substitute(properties=properties)
+        return properties
+
+    def get_set_optional_properties_query(self, node_name):
+        if len(self.optional_properties) == 0:
+            return None
+        return ",".join(
+            [prop.get_pattern(is_set=True, node_name=node_name) for prop in self.optional_properties])
+
+    def get_idt_properties_query(self, node_name):
+        if self.required_properties is None:
+            return None
+        return ",".join(
+            [f"{node_name}.{prop.attribute} as {prop.attribute}" for prop in self.required_properties])
+
+    def has_required_properties(self, with_optional=False):
+        if with_optional:
+            return len(self.required_properties) + len(self.optional_properties) > 0
+        return len(self.required_properties) > 0

--- a/src/promg/database_managers/db_connection.py
+++ b/src/promg/database_managers/db_connection.py
@@ -1,13 +1,7 @@
 from string import Template
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Tuple
 
-import neo4j
-from neo4j import GraphDatabase
-from neo4j.exceptions import ServiceUnavailable
-
-from . import authentication
-from .authentication import Credentials
-from ..utilities.singleton import Singleton
+from neo4j import GraphDatabase, ResultSummary, Transaction
 from ..utilities.configuration import Configuration
 
 
@@ -83,8 +77,7 @@ class DatabaseConnection:
         @return: The result of the query or None
         """
 
-        def run_query(tx: neo4j.Transaction, _query: str, **_kwargs) -> Optional[tuple[
-            List[Dict[str, Any]], neo4j.ResultSummary]]:
+        def run_query(tx: Transaction, _query: str, **_kwargs) -> Tuple[Optional[List[Dict[str, Any]]], ResultSummary]:
 
             """
                 Run the query and return the result of the query
@@ -101,7 +94,8 @@ class DatabaseConnection:
                 self.close_connection()
                 print(inst)
             else:
-                if _result_records is not None and _result_records != []:  # return the values if result is not none or empty list
+                if _result_records is not None and _result_records != []:  # return the values if result is not none
+                    # or empty list
                     return _result_records, _summary
                 else:
                     return None, _summary
@@ -113,7 +107,7 @@ class DatabaseConnection:
             database = self.db_name
 
         with self.driver.session(database=database) as session:
-            result, summary = session.execute_write(run_query, query, **kwargs)
+            result, _ = session.execute_write(run_query, query, **kwargs)
             return result
 
     @staticmethod


### PR DESCRIPTION
Put Properties in a seperate class so Nodes and Relationships can both make use of this class and reuse functionality.
Previously, Properties functionality was mostly spread over different classes. Now, it is in a seperate class (and file).