### PR TITLE
Put creation of indexing together with the clear database functionality. 

### DIFF
--- a/src/promg/modules/db_management.py
+++ b/src/promg/modules/db_management.py
@@ -7,7 +7,7 @@ from ..utilities.performance_handling import Performance
 
 
 class DBManagement:
-    def __init__(self, db_connection, semantic_header=None):
+    def __init__(self, db_connection, semantic_header):
         self.connection = db_connection
         self.semantic_header = semantic_header
 
@@ -17,11 +17,12 @@ class DBManagement:
         Replace or clear the entire database by a new one
 
         Args:
-            replace: boolean to indicate whether the database may be replaced
+            replace: boolean to indicate whether the database is fully replaced
 
         """
         if replace:
             result = self.connection.exec_query(dbm_ql.get_replace_db_query, **{"db_name": self.connection.db_name})
+            self.set_constraints()
             if result[0]['state'] == 'CaughtUp' and result[0]['success']:
                 return True
             else:
@@ -41,10 +42,10 @@ class DBManagement:
         # required by core pattern
         if self.semantic_header is not None:
             self._set_unique_sysid_constraints()
-        #
+        else:
+            self.connection.exec_query(dbm_ql.get_set_sysid_index_query)
         # self.connection.exec_query(dbm_ql.get_constraint_unique_log_id_query)
 
-        self.connection.exec_query(dbm_ql.get_set_sysid_index_query)
         self.connection.exec_query(dbm_ql.get_set_activity_index_query)
         self.connection.exec_query(dbm_ql.get_set_timestamp_event_index_query)
         self.connection.exec_query(dbm_ql.get_set_activity_event_index_query)

--- a/src/promg/modules/db_management.py
+++ b/src/promg/modules/db_management.py
@@ -7,7 +7,7 @@ from ..utilities.performance_handling import Performance
 
 
 class DBManagement:
-    def __init__(self, db_connection, semantic_header):
+    def __init__(self, db_connection, semantic_header=None):
         self.connection = db_connection
         self.semantic_header = semantic_header
 
@@ -36,11 +36,16 @@ class DBManagement:
         """
         Set constraints in Neo4j instance
         """
+        # # for implementation only (not required by schema or patterns)
+        # self.connection.exec_query(dbm_ql.get_constraint_unique_event_id_query)
+        #
+        # required by core pattern
+        if self.semantic_header is not None:
+            self._set_unique_sysid_constraints()
+        else:
+            self.connection.exec_query(dbm_ql.get_set_sysid_index_query)
+        # self.connection.exec_query(dbm_ql.get_constraint_unique_log_id_query)
 
-        # set sysid constrains as per semantic header
-        self._set_unique_sysid_constraints()
-
-        # set remaining constraints
         self.connection.exec_query(dbm_ql.get_set_activity_index_query)
         self.connection.exec_query(dbm_ql.get_set_timestamp_event_index_query)
         self.connection.exec_query(dbm_ql.get_set_activity_event_index_query)

--- a/src/promg/modules/db_management.py
+++ b/src/promg/modules/db_management.py
@@ -36,16 +36,11 @@ class DBManagement:
         """
         Set constraints in Neo4j instance
         """
-        # # for implementation only (not required by schema or patterns)
-        # self.connection.exec_query(dbm_ql.get_constraint_unique_event_id_query)
-        #
-        # required by core pattern
-        if self.semantic_header is not None:
-            self._set_unique_sysid_constraints()
-        else:
-            self.connection.exec_query(dbm_ql.get_set_sysid_index_query)
-        # self.connection.exec_query(dbm_ql.get_constraint_unique_log_id_query)
 
+        # set sysid constrains as per semantic header
+        self._set_unique_sysid_constraints()
+
+        # set remaining constraints
         self.connection.exec_query(dbm_ql.get_set_activity_index_query)
         self.connection.exec_query(dbm_ql.get_set_timestamp_event_index_query)
         self.connection.exec_query(dbm_ql.get_set_activity_event_index_query)


### PR DESCRIPTION
- Only creat sysid as index when semantic header is not specified.
- Set constraints (again) when replacing the database
- Make semantic header required