### PR TITLE
Update import method to make (:RecordType) nodes instead of saving everything as a label

### DIFF
--- a/src/promg/cypher_queries/data_importer_ql.py
+++ b/src/promg/cypher_queries/data_importer_ql.py
@@ -23,6 +23,17 @@ class DataImporterQueryLibrary:
         return mapping_str
 
     @staticmethod
+    def get_record_types_mapping(is_match, labels):
+        if is_match:
+            labels = [f'''MATCH (record:Record) - [:IS_OF_TYPE] -> (:RecordType {{type:"{label}"}})''' for label in labels]
+            record_types = "\n".join(labels)
+        else:
+            labels = [(f'''MERGE ({label}_record:RecordType {{type:"{label}"}}) \n'''
+                       f'''MERGE (record) - [:IS_OF_TYPE] -> ({label}_record)''') for label in labels]
+            record_types = "\n".join(labels)
+        return record_types
+
+    @staticmethod
     def get_import_directory_query() -> Query:
         """
         Query that gets the import directory of the current running database
@@ -39,9 +50,8 @@ class DataImporterQueryLibrary:
 
         return Query(query_str=query_str)
 
-
     @staticmethod
-    def get_create_nodes_by_loading_csv_query(labels: str, file_name: str, mapping: str) -> Query:
+    def get_create_nodes_by_loading_csv_query(labels: List[str], file_name: str, mapping: str) -> Query:
         """
         Create event nodes for each row in the batch with labels
         The properties of each row are also the property of the node
@@ -56,29 +66,32 @@ class DataImporterQueryLibrary:
         # (keys in our dictionary are string)
         # return is required when using call and yield
         # language=SQL
+
         query_str = '''
                     CALL apoc.periodic.iterate('
                         CALL apoc.load.csv("$file_name" $mapping_str) yield map as row return row',
-                        'CREATE (record:$labels)
-                        SET record += row'
+                        'CREATE (record:Record)
+                        SET record += row
+                        $record_types'
                     , {batchSize:10000, parallel:true, retries: 1});                    
                 '''
 
         return Query(query_str=query_str,
                      template_string_parameters={
                          "file_name": file_name,
-                         "labels": labels,
+                         "record_types": DataImporterQueryLibrary.get_record_types_mapping(is_match=False,
+                                                                                           labels=labels),
                          "mapping_str": DataImporterQueryLibrary.create_mapping_str(mapping)
                      })
 
     @staticmethod
-    def get_make_timestamp_date_query(required_labels_str: str, attribute: str, datetime_object: DatetimeObject,
+    def get_make_timestamp_date_query(required_labels: List[str], attribute: str, datetime_object: DatetimeObject,
                                       load_status: int) -> Query:
         """
         Create a query to convert the strings of the timestamp to the datetime as used in Neo4j
         Remove the str_timestamp property
 
-        @param required_labels_str: the required labels of the just imported nodes
+        @param required_labels: the required labels of the just imported nodes
         @param attribute: the name of the attribute that should be converted
         @param datetime_object: the DatetimeObject describing how the attribute should be converted
         @param load_status: the current load status of the records that are being imported
@@ -92,21 +105,22 @@ class DataImporterQueryLibrary:
         # language=SQL
         query_str = '''
                 CALL apoc.periodic.iterate(
-                'MATCH (r:$required_labels) 
-                USING INDEX r:Record(loadStatus)
-                WHERE r.$attribute IS NOT NULL AND r.loadStatus = $load_status 
-                AND NOT apoc.meta.cypher.isType(r.$attribute, "$date_type")
-                WITH r, r.$offset as timezone_dt
-                WITH r, datetime(apoc.date.convertFormat(timezone_dt, "$datetime_object_format", 
+                '$match_record_types 
+                USING INDEX record:Record(loadStatus)
+                WHERE record.$attribute IS NOT NULL AND record.loadStatus = $load_status 
+                AND NOT apoc.meta.cypher.isType(record.$attribute, "$date_type")
+                WITH record, record.$offset as timezone_dt
+                WITH record, datetime(apoc.date.convertFormat(timezone_dt, "$datetime_object_format", 
                     "$datetime_object_convert_to")) as converted
-                RETURN r, converted',
-                'SET r.$attribute = converted',
+                RETURN record, converted',
+                'SET record.$attribute = converted',
                 {batchSize:$batch_size, parallel:true})
             '''
 
         return Query(query_str=query_str,
                      template_string_parameters={
-                         "required_labels": required_labels_str,
+                         "match_record_types": DataImporterQueryLibrary.get_record_types_mapping(is_match=True,
+                                                                                           labels=labels),
                          "datetime_object_format": datetime_object.format,
                          "datetime_object_convert_to": datetime_object.convert_to,
                          "date_type": datetime_object.get_date_type(),
@@ -116,13 +130,14 @@ class DataImporterQueryLibrary:
                      })
 
     @staticmethod
-    def get_convert_epoch_to_timestamp_query(required_labels_str: str, attribute: str, datetime_object: DatetimeObject,
+    def get_convert_epoch_to_timestamp_query(required_labels: List[str], attribute: str,
+                                             datetime_object: DatetimeObject,
                                              load_status: int) -> Query:
         """
         Create a query to convert epoch timestamp to the datetime as used in Neo4j
         Remove the str_timestamp property
 
-        @param required_labels_str: the required labels of the just imported nodes
+        @param required_labels: the required labels of the just imported nodes
         @param attribute: the name of the attribute that should be converted
         @param datetime_object: the DatetimeObject describing how the attribute should be converted
         @param load_status: the current load status of the records that are being imported
@@ -134,14 +149,14 @@ class DataImporterQueryLibrary:
         # language=SQL
         query_str = '''
                 CALL apoc.periodic.iterate(
-                'MATCH (r:$required_labels) 
-                USING INDEX r:Record(loadStatus)
-                WHERE r.$attribute IS NOT NULL AND r.loadStatus = $load_status 
-                WITH r, r.$attribute as timezone_dt
-                WITH r, apoc.date.format(timezone_dt, $unit, 
+                '$match_record_types 
+                USING INDEX record:Record(loadStatus)
+                WHERE record.$attribute IS NOT NULL AND record.loadStatus = $load_status 
+                WITH record, record.$attribute as timezone_dt
+                WITH record, apoc.date.format(timezone_dt, $unit, 
                     $dt_format) as converted
-                RETURN r, converted',
-                'SET r.$attribute = converted',
+                RETURN record, converted',
+                'SET record.$attribute = converted',
                 {batchSize:$batch_size, parallel:false, 
                 params: {unit: $unit,
                         dt_format: $datetime_object_format}})
@@ -150,7 +165,8 @@ class DataImporterQueryLibrary:
         return Query(query_str=query_str,
                      template_string_parameters={
                          "attribute": attribute,
-                         "required_labels": required_labels_str
+                         "match_record_types": DataImporterQueryLibrary.get_record_types_mapping(is_match=True,
+                                                                                            labels=labels),
                      },
                      parameters={
                          "unit": datetime_object.unit,
@@ -159,11 +175,11 @@ class DataImporterQueryLibrary:
                      })
 
     @staticmethod
-    def get_finalize_import_records_query(required_labels_str: str, load_status: int) -> Query:
+    def get_finalize_import_records_query(required_labels: List[str], load_status: int) -> Query:
         """
         Create a query to finalize the import of the record nodes, i.e. remove the load status
 
-        @param required_labels_str: the required labels of the just imported nodes
+        @param required_labels: the required labels of the just imported nodes
         @param load_status: the current load status of the records that are being imported
 
         @return: Query object to remove the load status attribute of the just imported nodes
@@ -173,17 +189,19 @@ class DataImporterQueryLibrary:
         # language=SQL
         query_str = '''
             CALL apoc.periodic.commit(
-                'MATCH (r:$required_labels) 
-                USING INDEX r:Record(loadStatus)
-                WHERE r.loadStatus = $load_status
-                WITH r LIMIT $limit
-                REMOVE r.loadStatus
+                '$match_record_types
+                USING INDEX record:Record(loadStatus)
+                WHERE record.loadStatus = $load_status
+                WITH record LIMIT $limit
+                REMOVE record.loadStatus
                 RETURN count(*)',
                 {limit:$batch_size, load_status:$load_status})
             '''
 
         return Query(query_str=query_str,
-                     template_string_parameters={"required_labels": required_labels_str},
+                     template_string_parameters={
+                         "match_record_types": DataImporterQueryLibrary.get_record_types_mapping(is_match=True, labels=required_labels)
+                     },
                      parameters={
                          "load_status": load_status
                      }
@@ -191,7 +209,7 @@ class DataImporterQueryLibrary:
 
     @staticmethod
     def get_filter_records_by_property_query(prop: str, load_status: int, values: Optional[List[str]] = None,
-                                             exclude: bool = True, required_labels_str="Record") -> Query:
+                                             exclude: bool = True, required_labels=["Record"]) -> Query:
         """
         Create a query to remove nodes and their relationships if they have (exlude) or have not (include) a certain
         attribute or a certain attribute-value pairs.
@@ -201,7 +219,7 @@ class DataImporterQueryLibrary:
         @param values: a list of values that the property should (not) have for being removed
         @param exclude: boolean indicating whether nodes should be removed if they match the criteria (exclude=True)
         or be kept (exclude = False)
-        @param required_labels_str: the labels the nodes should have
+        @param required_labels: the labels the nodes should have
 
         @return: Query object to remove the load status attribute of the just imported nodes
 
@@ -212,8 +230,9 @@ class DataImporterQueryLibrary:
             # query to delete all records and its relationship with property
             # language=SQL
             query_str = '''
-                    MATCH (r:$required_labels {loadStatus: $load_status})
-                    WHERE r.$prop IS $negation NULL
+                    MATCH (record:Record {loadStatus: $load_status})
+                    $record_types
+                    WHERE record.$prop IS $negation NULL
                     DETACH DELETE r
                     '''
             template_string_parameters = {"prop": prop, "negation": negation}
@@ -222,16 +241,17 @@ class DataImporterQueryLibrary:
             # match all r and delete them and its relationship
             # language=SQL
             query_str = '''
-                    MATCH (r:$required_labels {loadStatus: $load_status})
-                    WHERE $negation r.$prop IN $values
-                    DETACH DELETE r
+                    $match_record_types 
+                    WHERE record.loadStatus = $load_status
+                    AND $negation record.$prop IN $values
+                    DETACH DELETE record
                 '''
             template_string_parameters = {
                 "prop": prop,
                 "negation": negation,
                 "values": values,
                 "load_status": load_status,
-                "required_labels": required_labels_str
+                "match_record_types": DataImporterQueryLibrary.get_record_types_mapping(is_match=True, labels=labels)
             }
 
         # execute query

--- a/src/promg/modules/data_importer.py
+++ b/src/promg/modules/data_importer.py
@@ -40,7 +40,7 @@ class Importer:
 
     def import_data(self, to_be_imported_logs) -> None:
         for structure in self.structures:
-            required_labels_str = structure.get_required_labels_str(records=self.records)
+            required_labels = structure.get_required_labels(records=self.records)
 
             # read in all file names that match this structure
             for file_name in structure.file_names:
@@ -56,41 +56,41 @@ class Importer:
                     df_log = structure.determine_optional_labels_in_log(df_log, records=self.records)
 
                     self._import_nodes_from_data(df_log=df_log, file_name=file_name,
-                                                 required_labels_str=required_labels_str)
+                                                 required_labels=required_labels)
 
                     if structure.has_datetime_attribute():
                         # once all events are imported, we convert the string timestamp to the timestamp as used in
                         # Cypher
-                        self._reformat_timestamps(structure=structure, required_labels_str=required_labels_str)
+                        self._reformat_timestamps(structure=structure, required_labels=required_labels)
 
                     # TODO: move filtering to pandas dataframe
                     self._filter_nodes(structure=structure,
-                                       required_labels_str=required_labels_str)  # filter nodes according to the
+                                       required_labels=required_labels)  # filter nodes according to the
                     # structure
-                    self._finalize_import(required_labels_str=required_labels_str)  # removes temporary properties
+                    self._finalize_import(required_labels=required_labels)  # removes temporary properties
 
     @Performance.track("structure")
-    def _reformat_timestamps(self, structure, required_labels_str):
+    def _reformat_timestamps(self, structure, required_labels):
         datetime_formats = structure.get_datetime_formats()
         for attribute, datetime_format in datetime_formats.items():
             if datetime_format.is_epoch:
                 self.connection.exec_query(di_ql.get_convert_epoch_to_timestamp_query,
                                            **{
-                                               "required_labels_str": required_labels_str,
+                                               "required_labels": required_labels,
                                                "attribute": attribute,
                                                "datetime_object": datetime_format
                                            })
-
             self.connection.exec_query(di_ql.get_make_timestamp_date_query,
                                        **{
-                                           "required_labels_str": required_labels_str,
+                                           "required_labels": required_labels,
                                            "attribute": attribute,
                                            "datetime_object": datetime_format,
                                            "load_status": self.load_status
                                        })
 
+
     @Performance.track("structure")
-    def _filter_nodes(self, structure, required_labels_str):
+    def _filter_nodes(self, structure, required_labels):
         for exclude in [True, False]:
             attribute_values_pairs_filtered = structure.get_attribute_value_pairs_filtered(exclude=exclude)
             for name, values in attribute_values_pairs_filtered.items():
@@ -100,36 +100,39 @@ class Importer:
                                                "values": values,
                                                "exclude": exclude,
                                                "load_status": self.load_status,
-                                               "required_labels_str": required_labels_str
+                                               "required_labels": required_labels
                                            })
 
     @Performance.track("structure")
-    def _finalize_import(self, required_labels_str):
+    def _finalize_import(self, required_labels):
         # finalize the import
         self.connection.exec_query(di_ql.get_finalize_import_records_query,
                                    **{
                                        "load_status": self.load_status,
-                                       "required_labels_str": required_labels_str
+                                       "required_labels": required_labels
                                    })
         self.load_status = 0
 
     @Performance.track("file_name")
-    def _import_nodes_from_data(self, df_log, file_name, required_labels_str):
+    def _import_nodes_from_data(self, df_log, file_name, required_labels):
         grouped_by_optional_labels = df_log.groupby(by="labels")
         mapping_str = self._determine_column_mapping_str(df_log)
 
         for optional_labels_str, log in grouped_by_optional_labels:
-            labels_str = required_labels_str + optional_labels_str
+            optional_labels = optional_labels_str.split(":")
+            labels = required_labels + optional_labels
+            labels = list(set(labels))
+            labels.remove("")
             new_file_name = self.determine_new_file_name(file_name, optional_labels_str)
-            self.import_log_into_db(file_name=new_file_name, labels_str=labels_str, mapping_str=mapping_str, log=log)
+            self.import_log_into_db(file_name=new_file_name, labels=labels, mapping_str=mapping_str, log=log)
 
-    def import_log_into_db(self, file_name, labels_str, mapping_str, log):
+    def import_log_into_db(self, file_name, labels, mapping_str, log):
         # Temporary save the file in the import directory
         self._save_log_grouped_by_labels(log=log, file_name=file_name)
         self.connection.exec_query(di_ql.get_create_nodes_by_loading_csv_query,
                                    **{
                                        "file_name": file_name,
-                                       "labels": labels_str,
+                                       "labels": labels,
                                        "mapping": mapping_str
                                    })
 


### PR DESCRIPTION
Previously, a `(:Record)` node would contain additional labels to indicate the type of information the node carries.
So, for instance if a `(:Record)` node contained information about an event, it would have an additional `EventRecord` label.

As a result, a single `(:Record)` node could have a lot of labels leading to _label overload_, which slows down the performance.
It's recommended for a node to have max four labels [(see here)](https://medium.com/neo4j/graph-modeling-labels-71775ff7d121).

So, instead we create a `(:RecordType)` nodes that carry as an attribute `type`. 
Then, if  a `(:Record)` node contained information about an event, it would be related to the `(:RecordType {type:'EventRecord'})` node via a `[:IS_OF_TYPE]` relationship.
