### PR TITLE
Update workflow to only run when a release is made.

### DIFF
--- a/.github/workflows/python-publish-main-with-current-version.yml
+++ b/.github/workflows/python-publish-main-with-current-version.yml
@@ -1,0 +1,30 @@
+# This workflow will build a new python package with the current version and uploads it to PyPI
+# when a new release is published.
+
+name: Publish Python 🐍 distributions 📦 to PyPI
+
+on: 
+  release:
+    types: [published]
+  workflow_dispatch:
+jobs:
+  set-up-python:
+    uses: ./.github/workflows/call-python-setup.yml
+  build-python-distribution:
+    uses: ./.github/workflows/call-python-build.yml
+    needs: set-up-python
+  publish-artifact:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    needs: build-python-distribution
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download dist artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: dist
+        path: dist
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+  

--- a/.github/workflows/python-publish-main-with-current-version.yml
+++ b/.github/workflows/python-publish-main-with-current-version.yml
@@ -6,7 +6,7 @@ name: Publish Python 🐍 distributions 📦 to PyPI
 on: 
   release:
     types: [published]
-  workflow_dispatch:
+  workflow_dispatch: # using this allows us to manually run the workflow in Github
 jobs:
   set-up-python:
     uses: ./.github/workflows/call-python-setup.yml


### PR DESCRIPTION
Previously, we only had a workflow that would always update the patch version (so from x.y.z to x.y.z+1) when we pushed something to the `main` branch, then build and publish the package on PyPi.
However, this is very limited as sometimes we want to make minor or major releases.

Now, we have created a workflow that will build and publish a package to PyPi when we publish a new release.
Instead of automatically bumping the version number, the version number needs to be set manually in version.md (_which should correspond with the tag_). This allows us to update the patch, minor and major version.