### PR TITLE
Update import method to make (:Log) nodes instead of saving it as an attribute in the (:Record) nodes

### DIFF
--- a/src/promg/cypher_queries/data_importer_ql.py
+++ b/src/promg/cypher_queries/data_importer_ql.py
@@ -85,6 +85,18 @@ class DataImporterQueryLibrary:
                      })
 
     @staticmethod
+    def get_merge_log_nodes_query():
+        query_str = '''
+                            MATCH (log:Log)
+                            WITH log.name as name, collect(log) as logs
+                            CALL apoc.refactor.mergeNodes(logs, {properties: "discard", mergeRels: true})
+                            YIELD node
+                            RETURN node                
+                        '''
+
+        return Query(query_str=query_str)
+
+    @staticmethod
     def get_make_timestamp_date_query(required_labels_str: str, attribute: str, datetime_object: DatetimeObject,
                                       load_status: int) -> Query:
         """

--- a/src/promg/cypher_queries/db_managment_ql.py
+++ b/src/promg/cypher_queries/db_managment_ql.py
@@ -121,20 +121,11 @@ class DBManagementQueryLibrary:
                          "entity_key_name": entity_key_name})
 
     @staticmethod
-    def get_set_activity_event_index_query() -> Query:
+    def get_set_activity_index_query() -> Query:
         # language=SQL
         query_str = '''
-                CREATE RANGE INDEX activity_event_index 
-                IF NOT EXISTS FOR (e:Event) ON (e.activity)
-            '''
-        return Query(query_str=query_str)
-
-    @staticmethod
-    def get_set_timestamp_event_index_query() -> Query:
-        # language=SQL
-        query_str = '''
-                CREATE RANGE INDEX timestamp_event_index 
-                IF NOT EXISTS FOR (e:Event) ON (e.timestamp)
+                CREATE RANGE INDEX activity_index 
+                IF NOT EXISTS FOR (a:Activity) ON (a.activity)
             '''
         return Query(query_str=query_str)
 

--- a/src/promg/cypher_queries/semantic_header_ql.py
+++ b/src/promg/cypher_queries/semantic_header_ql.py
@@ -90,7 +90,10 @@ class SemanticHeaderQueryLibrary:
                     CALL apoc.periodic.iterate(
                     'MATCH ($record) $log_check_str
                     $record_matches
-                          RETURN record',
+                    // order records by elementId, this will determine the order in which events are created
+                    // this is important for the temporal ordering of :Event nodes 
+                    // when creating DF edges in case the timestamps are similar
+                          RETURN record ORDER BY elementId(record)',
                           '$merge_or_create_node
                           $set_label_str
                           $set_property_str

--- a/src/promg/cypher_queries/semantic_header_ql.py
+++ b/src/promg/cypher_queries/semantic_header_ql.py
@@ -62,15 +62,14 @@ class SemanticHeaderQueryLibrary:
         # add check to only transform records from the imported logs
         if logs is not None:
             log_str = ",".join([f'"{log}"' for log in logs])
-            log_check_str = f"WHERE record.log in [{log_str}]"
+            log_check_str = f"<- [:CONTAINS] - (log:Log) WHERE log.name in [{log_str}]"
         else:
             log_check_str = ""
 
         # language=SQL
         query_str = '''
                     CALL apoc.periodic.iterate(
-                    'MATCH ($record) 
-                          $log_check_str
+                    'MATCH ($record) $log_check_str
                           RETURN record',
                           '$merge_or_create ($result_node)
                           $set_label_str
@@ -107,8 +106,8 @@ class SemanticHeaderQueryLibrary:
         log_str = f"[{log_str}]"
 
         query_str = '''
-            MATCH (r:Record)
-            WHERE r.log in $log_str
+            MATCH (r:Record) <- [:CONTAINS] - (log:Log)
+            WHERE log.name in $log_str
             UNWIND labels(r) as _label
             RETURN collect(distinct _label) as labels
         '''
@@ -206,13 +205,12 @@ class SemanticHeaderQueryLibrary:
         # add check to only transform records from the imported logs
         if logs is not None:
             log_str = ",".join([f'"{log}"' for log in logs])
-            log_check_str = f"WHERE record.log in [{log_str}]"
+            log_check_str = f"<- [:CONTAINS] - (log:Log) WHERE log.name in [{log_str}]"
         else:
             log_check_str = ""
 
         query_str = '''     CALL apoc.periodic.iterate('
-                            MATCH (record:$record_labels)
-                            $log_check_str
+                            MATCH (record:$record_labels) $log_check_str
                             RETURN record',
                             '
                             MATCH ($from_node) - [:EXTRACTED_FROM] -> (record)

--- a/src/promg/cypher_queries/semantic_header_ql.py
+++ b/src/promg/cypher_queries/semantic_header_ql.py
@@ -90,7 +90,6 @@ class SemanticHeaderQueryLibrary:
                     CALL apoc.periodic.iterate(
                     'MATCH ($record) $log_check_str
                     $record_matches
-                          $log_check_str
                           RETURN record',
                           '$merge_or_create_node
                           $set_label_str
@@ -131,8 +130,7 @@ class SemanticHeaderQueryLibrary:
             MATCH (record:Record) - [:IS_OF_TYPE] -> (record_type:RecordType)
             MATCH (record) <- [:CONTAINS] - (log:Log)
             WHERE log.name in $log_str
-            UNWIND labels(r) as _label
-            RETURN collect(distinct _label) as labels
+            RETURN collect(distinct record_type.type) as labels
         '''
 
         return Query(query_str=query_str,

--- a/src/promg/modules/data_importer.py
+++ b/src/promg/modules/data_importer.py
@@ -147,6 +147,8 @@ class Importer:
                                        "mapping": mapping_str
                                    })
 
+        self.connection.exec_query(di_ql.get_merge_log_nodes_query)
+
         # delete the file from the import directory
         self._delete_log_grouped_by_labels(file_name=file_name)
 

--- a/src/promg/modules/data_importer.py
+++ b/src/promg/modules/data_importer.py
@@ -72,7 +72,7 @@ class Importer:
 
                     self._import_nodes_from_data(df_log=df_log,
                                                  file_name=file_name,
-                                                 required_labels_str=required_labels)
+                                                 required_labels=required_labels)
 
                     if structure.has_datetime_attribute():
                         # once all events are imported, we convert the string timestamp to the timestamp as used in

--- a/src/promg/modules/db_management.py
+++ b/src/promg/modules/db_management.py
@@ -37,8 +37,7 @@ class DBManagement:
         """
         self._set_sysid_constraints(entity_key_name=entity_key_name)
         self.connection.exec_query(dbm_ql.get_set_unique_log_name_index_query)
-        self.connection.exec_query(dbm_ql.get_set_timestamp_event_index_query)
-        self.connection.exec_query(dbm_ql.get_set_activity_event_index_query)
+        self.connection.exec_query(dbm_ql.get_set_activity_index_query)
         self.connection.exec_query(dbm_ql.get_set_record_id_as_unique_query)
 
     def _set_sysid_constraints(self, entity_key_name="sysId"):

--- a/version.md
+++ b/version.md
@@ -1,1 +1,1 @@
-# version 1.1.3
+# version 1.1.4


### PR DESCRIPTION
Previously, a `(:Record)` node would contain the `log` as an attribute to indicate the log the record coms from.
So, for instance if a `(:Record)` node comes from csv named _log.csv_, it would carry the attribute `log = 'log.csv'`

As a result, many `(:Record)` nodes would share a small number of attributes, so we would have a  lot of duplicate data.
It's recommended to eliminate duplicate data by storing the attribute in a seperate node as it improves the query performance and to reduce the amount of storage required for the graph [(see here)](https://graphacademy.neo4j.com/courses/modeling-fundamentals/6-eliminating-duplicate-data/1-duplicate-data/). 

So, instead we create a `(:Log)` node that carries the log name as an attribute type.
Then, if a `(:Record)` comes from a specific log, it would be related to the `(:Log {name:'log.csv'})` node via a `[:CONTAINS]` relationship.