### PR TITLE
Refactor/improve performance

### DIFF
--- a/src/promg/cypher_queries/data_importer_ql.py
+++ b/src/promg/cypher_queries/data_importer_ql.py
@@ -20,17 +20,12 @@ def create_mapping_str(mapping: str) -> str:
     return mapping_str
 
 
-def get_record_types_mapping(is_match, labels):
-    if is_match:
-        if len(labels) == 0:
-            return "MATCH (record:Record)"
-        labels = [f'''MATCH (record:Record) - [:IS_OF_TYPE] -> (:RecordType {{type:"{label}"}})''' for label in
-                  labels]
-        record_types = "\n".join(labels)
-    else:
-        labels = [(f'''MERGE ({label}_record:RecordType {{type:"{label}"}}) \n'''
-                   f'''MERGE (record) - [:IS_OF_TYPE] -> ({label}_record)''') for label in labels]
-        record_types = "\n".join(labels)
+def get_match_record_types_mapping(labels):
+    if len(labels) == 0:
+        return "MATCH (record:Record)"
+    record_types = "\n".join(
+        [f'''MATCH (record:Record) - [:IS_OF_TYPE] -> (:RecordType {{type:"{label}"}})''' for label in
+         labels])
     return record_types
 
 
@@ -53,6 +48,14 @@ class DataImporterQueryLibrary:
         return Query(query_str=query_str)
 
     @staticmethod
+    def get_create_record_types_and_log_query(labels: List[str], log_name: str = None) -> Query:
+        query_str = "\n".join(
+            [f'''MERGE (:RecordType {{type:"{label}"}})''' for label in labels])
+        query_str += f'''\nMERGE (:Log {{name:"{log_name}"}})''' if log_name is not None else ""
+
+        return Query(query_str=query_str)
+
+    @staticmethod
     def get_create_nodes_by_loading_csv_query(labels: List[str], file_name: str, mapping: str,
                                               log_name: str = None) -> Query:
         """
@@ -67,30 +70,37 @@ class DataImporterQueryLibrary:
         """
 
         if log_name is not None:
-            log_str = '''MERGE (log:Log {name:$log_name})
-                        MERGE (record)<-[:CONTAINS]-(log)'''
+            match_log_str = '''\n MATCH (log:Log {name:$log_name})'''
+            create_log_str = '''CREATE (record)<-[:CONTAINS]-(log)'''
         else:
-            log_str = ""
+            match_log_str = ""
+            create_log_str = ""
             log_name = ""
+
+        match_record_types = "\n".join(
+            [f'''MATCH ({label}_record:RecordType {{type:"{label}"}})''' for label in labels])
+        match_record_types += match_log_str
+
+        create_records = "\n".join([f'''CREATE (record) - [:IS_OF_TYPE] -> ({label}_record)''' for label in labels])
+        create_records += create_log_str
 
         # language=SQL
         query_str = '''
                     CALL apoc.periodic.iterate('
                         CALL apoc.load.csv("$file_name" $mapping_str) yield map as row return row',
-                        'CREATE (record:Record)
-                        $log_str
-                        SET record += row
-                        $set_record_types'
+                        '$match_record_types
+                        CREATE (record:Record)
+                        $create_records
+                        SET record += row '
                     , {batchSize:10000, parallel:true, retries: 1, params:{log_name: $log_name}});                    
                 '''
 
         return Query(query_str=query_str,
                      template_string_parameters={
                          "file_name": file_name,
-                         "set_record_types": get_record_types_mapping(is_match=False,
-                                                                      labels=labels),
                          "mapping_str": create_mapping_str(mapping),
-                         "log_str": log_str
+                         "match_record_types": match_record_types,
+                         "create_records": create_records
                      },
                      parameters={
                          "log_name": log_name
@@ -109,8 +119,8 @@ class DataImporterQueryLibrary:
         return Query(query_str=query_str)
 
     @staticmethod
-    def get_make_timestamp_date_query(required_labels: List[str], attribute: str, datetime_object: DatetimeObject,
-                                      load_status: int) -> Query:
+    def get_make_timestamp_date_query(required_labels: List[str], attribute: str,
+                                      datetime_object: DatetimeObject) -> Query:
         """
         Create a query to convert the strings of the timestamp to the datetime as used in Neo4j
         Remove the str_timestamp property
@@ -118,7 +128,6 @@ class DataImporterQueryLibrary:
         @param required_labels: the required labels of the just imported nodes
         @param attribute: the name of the attribute that should be converted
         @param datetime_object: the DatetimeObject describing how the attribute should be converted
-        @param load_status: the current load status of the records that are being imported
 
         @return: Query object to convert the timestamps string into timestamp objects
 
@@ -130,9 +139,7 @@ class DataImporterQueryLibrary:
         query_str = '''
                 CALL apoc.periodic.iterate(
                 '$match_record_types 
-                USING INDEX record:Record(loadStatus)
-                WHERE record.$attribute IS NOT NULL AND record.loadStatus = $load_status 
-                AND NOT apoc.meta.cypher.isType(record.$attribute, "$date_type")
+                WHERE record.$attribute IS NOT NULL AND NOT apoc.meta.cypher.isType(record.$attribute, "$date_type")
                 WITH record, record.$offset as timezone_dt
                 WITH record, datetime(apoc.date.convertFormat(timezone_dt, "$datetime_object_format", 
                     "$datetime_object_convert_to")) as converted
@@ -143,20 +150,17 @@ class DataImporterQueryLibrary:
 
         return Query(query_str=query_str,
                      template_string_parameters={
-                         "match_record_types": get_record_types_mapping(is_match=True,
-                                                                        labels=required_labels),
+                         "match_record_types": get_match_record_types_mapping(labels=required_labels),
                          "datetime_object_format": datetime_object.format,
                          "datetime_object_convert_to": datetime_object.convert_to,
                          "date_type": datetime_object.get_date_type(),
                          "attribute": attribute,
-                         "offset": offset,
-                         "load_status": load_status
+                         "offset": offset
                      })
 
     @staticmethod
     def get_convert_epoch_to_timestamp_query(required_labels: List[str], attribute: str,
-                                             datetime_object: DatetimeObject,
-                                             load_status: int) -> Query:
+                                             datetime_object: DatetimeObject) -> Query:
         """
         Create a query to convert epoch timestamp to the datetime as used in Neo4j
         Remove the str_timestamp property
@@ -164,7 +168,6 @@ class DataImporterQueryLibrary:
         @param required_labels: the required labels of the just imported nodes
         @param attribute: the name of the attribute that should be converted
         @param datetime_object: the DatetimeObject describing how the attribute should be converted
-        @param load_status: the current load status of the records that are being imported
 
         @return: Query object to convert the epoch timestamps into timestamp objects
 
@@ -174,11 +177,9 @@ class DataImporterQueryLibrary:
         query_str = '''
                 CALL apoc.periodic.iterate(
                 '$match_record_types 
-                USING INDEX record:Record(loadStatus)
-                WHERE record.$attribute IS NOT NULL AND record.loadStatus = $load_status 
+                WHERE record.$attribute IS NOT NULL AND NOT apoc.meta.cypher.isType(record.$attribute, "$date_type")
                 WITH record, record.$attribute as timezone_dt
-                WITH record, apoc.date.format(timezone_dt, $unit, 
-                    $dt_format) as converted
+                WITH record, apoc.date.format(timezone_dt, $unit, $dt_format) as converted
                 RETURN record, converted',
                 'SET record.$attribute = converted',
                 {batchSize:$batch_size, parallel:false, 
@@ -189,140 +190,73 @@ class DataImporterQueryLibrary:
         return Query(query_str=query_str,
                      template_string_parameters={
                          "attribute": attribute,
-                         "match_record_types": get_record_types_mapping(is_match=True,
-                                                                        labels=required_labels)
+                         "match_record_types": get_match_record_types_mapping(labels=required_labels)
                      },
                      parameters={
                          "unit": datetime_object.unit,
-                         "datetime_object_format": datetime_object.format,
-                         "load_status": load_status
+                         "datetime_object_format": datetime_object.format
                      })
 
-    @staticmethod
-    def get_finalize_import_records_query(required_labels: List[str], load_status: int) -> Query:
-        """
-        Create a query to finalize the import of the record nodes, i.e. remove the load status
 
-        @param required_labels: the required labels of the just imported nodes
-        @param load_status: the current load status of the records that are being imported
 
-        @return: Query object to remove the load status attribute of the just imported nodes
+@staticmethod
+def get_filter_records_by_property_query(prop: str, values: Optional[List[str]] = None,
+                                         exclude: bool = True, required_labels=["Record"]) -> Query:
+    """
+    Create a query to remove nodes and their relationships if they have (exlude) or have not (include) a certain
+    attribute or a certain attribute-value pairs.
 
-        """
+    @param prop: the name of the property
+    @param values: a list of values that the property should (not) have for being removed
+    @param exclude: boolean indicating whether nodes should be removed if they match the criteria (exclude=True)
+    or be kept (exclude = False)
+    @param required_labels: the labels the nodes should have
 
+    @return: Query object to remove the load status attribute of the just imported nodes
+
+    """
+
+    if values is None:  # match all events that have a specific property
+        negation = "NOT" if exclude else ""
+        # query to delete all records and its relationship with property
         # language=SQL
         query_str = '''
-            CALL apoc.periodic.iterate(
-                // find all correct record types with the correct load status
-                '$match_record_types
-                USING INDEX record:Record(loadStatus)
-                WHERE record.loadStatus = $load_status
-                RETURN record',
-                // remove the status
-                'REMOVE record.loadStatus',
-                {batchSize:$batch_size, params:{load_status:$load_status}})
-            '''
-
-        return Query(query_str=query_str,
-                     template_string_parameters={
-                         "match_record_types": get_record_types_mapping(is_match=True,
-                                                                        labels=required_labels)
-                     },
-                     parameters={
-                         "load_status": load_status
-                     }
-                     )
-
-    @staticmethod
-    def get_filter_records_by_property_query(prop: str, load_status: int, values: Optional[List[str]] = None,
-                                             exclude: bool = True, required_labels=["Record"]) -> Query:
-        """
-        Create a query to remove nodes and their relationships if they have (exlude) or have not (include) a certain
-        attribute or a certain attribute-value pairs.
-
-        @param prop: the name of the property
-        @param load_status: the current load status of the records that are being imported
-        @param values: a list of values that the property should (not) have for being removed
-        @param exclude: boolean indicating whether nodes should be removed if they match the criteria (exclude=True)
-        or be kept (exclude = False)
-        @param required_labels: the labels the nodes should have
-
-        @return: Query object to remove the load status attribute of the just imported nodes
-
-        """
-
-        if values is None:  # match all events that have a specific property
-            negation = "NOT" if exclude else ""
-            # query to delete all records and its relationship with property
-            # language=SQL
-            query_str = '''
                     CALL apoc.periodic.iterate(
-                    // match all records that match loadstatus and property
+                    // match all records that match property
                     '$match_record_types 
-                    WHERE record.loadStatus = $load_status
                     WHERE record.$prop IS $negation NULL
                     RETURN record',
                     // delete record and its relationships
                     'DETACH DELETE record',
                     // pass the query parameters
-                    {batchSize:$batch_size, params:{load_status:$load_status}})
+                    {batchSize:$batch_size})
                     '''
-            template_string_parameters = {"prop": prop, "negation": negation}
-        else:  # match all events with specific property and value
-            negation = "" if exclude else "NOT"
-            # match all r and delete them and its relationship
-            # language=SQL
-            query_str = '''
+        template_string_parameters = {"prop": prop, "negation": negation}
+    else:  # match all events with specific property and value
+        negation = "" if exclude else "NOT"
+        # match all r and delete them and its relationship
+        # language=SQL
+        query_str = '''
             CALL apoc.periodic.iterate(
-                // match all records that match loadstatus and property
+                // match all records that match property
                     '$match_record_types 
-                    WHERE record.loadStatus = $load_status
-                    AND $negation record.$prop IN $values
+                    WHERE $negation record.$prop IN $values
                     RETURN record',
                     // delete record and its relationships
                     'DETACH DELETE record',
                     // pass the query parameters
-                    {batchSize:$batch_size, params:{load_status:$load_status, values:$values}})
+                    {batchSize:$batch_size, params:{values:$values}})
                     
                 '''
-            template_string_parameters = {
-                "prop": prop,
-                "negation": negation,
-                "match_record_types": get_record_types_mapping(is_match=True,
-                                                               labels=required_labels)
-            }
+        template_string_parameters = {
+            "prop": prop,
+            "negation": negation,
+            "match_record_types": get_match_record_types_mapping(labels=required_labels)
+        }
 
-        # execute query
-        return Query(query_str=query_str,
-                     template_string_parameters=template_string_parameters,
-                     parameters={
-                         "load_status": load_status,
-                         "values": values
-                     })
-
-    @staticmethod
-    def get_update_load_status_query(current_load_status: int):
-        """
-        Create a query to update the record nodes that match the current load status with 1
-
-        @param current_load_status: the current load status of the records that are being imported
-
-        @return: Query object that updates the Record nodes that match the current load status with 1
-
-        """
-
-        # language=SQL
-        query_str = '''
-        CALL apoc.periodic.iterate(
-        // match records with correct load status
-            'MATCH (record:Record) 
-            WHERE record.loadStatus = $old_value
-            RETURN record',
-            // update the load status
-            'SET record.loadStatus = record.loadStatus + 1',
-            {batchSize:$batch_size, params:{old_value:$old_value}})
-                            '''
-        return Query(query_str=query_str,
-                     parameters={
-                         "old_value": current_load_status
-                     })
+    # execute query
+    return Query(query_str=query_str,
+                 template_string_parameters=template_string_parameters,
+                 parameters={
+                     "values": values
+                 })

--- a/src/promg/cypher_queries/db_managment_ql.py
+++ b/src/promg/cypher_queries/db_managment_ql.py
@@ -130,15 +130,20 @@ class DBManagementQueryLibrary:
         return Query(query_str=query_str)
 
     @staticmethod
-    def get_set_record_id_as_unique_query() -> Query:
+    def get_set_record_id_as_range_query() -> Query:
         # language=SQL
         query_str = '''
-            CREATE CONSTRAINT record_id_as_unique_property IF NOT EXISTS 
-            FOR (r:Record) REQUIRE r.recordId IS UNIQUE
-            // also set the range index
-            OPTIONS {
-              indexProvider: 'range-1.0'
-            }
+                CREATE RANGE INDEX record_id_range 
+                IF NOT EXISTS FOR (r:Record) ON (r.recordId)
+        '''
+        return Query(query_str=query_str)
+
+    @staticmethod
+    def get_set_record_type_range_query() -> Query:
+        # language=SQL
+        query_str = '''
+                CREATE RANGE INDEX record_type_range 
+                IF NOT EXISTS FOR (rt:RecordType) ON (rt.type)
         '''
         return Query(query_str=query_str)
 

--- a/src/promg/data_managers/datastructures.py
+++ b/src/promg/data_managers/datastructures.py
@@ -470,7 +470,7 @@ class DataStructure:
         required_labels_str = ":".join(required_labels_w_records)
         return required_labels_str
 
-    def read_data_set(self, file_name, use_sample, load_status: int, store_preprocessed_file=True,
+    def read_data_set(self, file_name, use_sample, store_preprocessed_file=True,
                       use_preprocessed_file=False):
         preprocessed_file_name = self._get_preprocessed_file_name(file_name, use_sample)
         df_log = None
@@ -481,7 +481,6 @@ class DataStructure:
             if store_preprocessed_file:
                 self.store_df_log(df_log, preprocessed_file_name)
 
-        df_log["loadStatus"] = load_status
         return df_log
 
     def read_df_log(self, file_name, use_sample):

--- a/src/promg/modules/data_importer.py
+++ b/src/promg/modules/data_importer.py
@@ -42,16 +42,8 @@ class Importer:
         self.use_sample = use_sample
         self.use_preprocessed_files = use_preprocessed_files
         self.store_files = store_files
-        self.load_status = 0
 
         self._import_directory = import_directory
-
-    def update_load_status(self):
-        self.connection.exec_query(di_ql.get_update_load_status_query,
-                                   **{
-                                       "current_load_status": self.load_status
-                                   })
-        self.load_status += 1
 
     def import_data(self, to_be_imported_logs) -> None:
         for structure in self.structures:
@@ -65,7 +57,6 @@ class Importer:
                     df_log = structure.read_data_set(file_name=file_name,
                                                      use_sample=self.use_sample,
                                                      use_preprocessed_file=self.use_preprocessed_files,
-                                                     load_status=self.load_status,
                                                      store_preprocessed_file=self.store_files)
 
                     df_log = structure.determine_optional_labels_in_log(df_log, records=self.records)
@@ -83,7 +74,6 @@ class Importer:
                     self._filter_nodes(structure=structure,
                                        required_labels=required_labels)  # filter nodes according to the
                     # structure
-                    self._finalize_import(required_labels=required_labels)  # removes temporary properties
 
     @Performance.track("structure")
     def _reformat_timestamps(self, structure, required_labels):
@@ -101,8 +91,7 @@ class Importer:
                                        **{
                                            "required_labels": required_labels,
                                            "attribute": attribute,
-                                           "datetime_object": datetime_format,
-                                           "load_status": self.load_status
+                                           "datetime_object": datetime_format
                                        })
 
     @Performance.track("structure")
@@ -115,19 +104,8 @@ class Importer:
                                                "prop": name,
                                                "values": values,
                                                "exclude": exclude,
-                                               "load_status": self.load_status,
                                                "required_labels": required_labels
                                            })
-
-    @Performance.track("structure")
-    def _finalize_import(self, required_labels):
-        # finalize the import
-        self.connection.exec_query(di_ql.get_finalize_import_records_query,
-                                   **{
-                                       "load_status": self.load_status,
-                                       "required_labels": required_labels
-                                   })
-        self.load_status = 0
 
     @Performance.track("file_name")
     def _import_nodes_from_data(self, df_log, file_name, required_labels):
@@ -147,6 +125,13 @@ class Importer:
         log, log_name = pop_log_name(log)
 
         self._save_log_grouped_by_labels(log=log, file_name=file_name)
+        # first create the record types and log nodes
+        self.connection.exec_query(di_ql.get_create_record_types_and_log_query,
+                                   **{
+                                       "labels": labels,
+                                       "log_name": log_name
+                                   })
+        # when creating the records nodes, relations between the record types and log nodes are created
         self.connection.exec_query(di_ql.get_create_nodes_by_loading_csv_query,
                                    **{
                                        "file_name": file_name,

--- a/src/promg/modules/db_management.py
+++ b/src/promg/modules/db_management.py
@@ -38,7 +38,8 @@ class DBManagement:
         self._set_sysid_constraints(entity_key_name=entity_key_name)
         self.connection.exec_query(dbm_ql.get_set_unique_log_name_index_query)
         self.connection.exec_query(dbm_ql.get_set_activity_index_query)
-        self.connection.exec_query(dbm_ql.get_set_record_id_as_unique_query)
+        self.connection.exec_query(dbm_ql.get_set_record_id_as_range_query)
+        self.connection.exec_query(dbm_ql.get_set_record_type_range_query)
 
     def _set_sysid_constraints(self, entity_key_name="sysId"):
         if self.semantic_header is not None:

--- a/version.md
+++ b/version.md
@@ -1,1 +1,1 @@
-# version 2.0.0
+# version 2.1.0


### PR DESCRIPTION
We improve performance threefold

- Instead of merging the `(:RecordType)` and `(:Log)` nodes for each imported `(:Record)` node, we first merge the `(:RecordType)` and `(:Log)` nodes in a seperate query. Then, when creating the `(:Record)` nodes, we look for the previously created nodes via a `MATCH` and then create the relationships.
- Remove the `loadStatus` attributes from the code. This was still some legacy attribute we used when using `apoc.periodic.commit`, however, we switched to `apoc.periodic.iterate` functions.
- Replace unqiue constraints by range constraints for the recordId and add a constraint for the record types