### PR TITLE
Refactor/fix minor issues

### DIFF
--- a/src/promg/cypher_queries/db_managment_ql.py
+++ b/src/promg/cypher_queries/db_managment_ql.py
@@ -207,8 +207,8 @@ class DBManagementQueryLibrary:
     def get_imported_logs_query() -> Query:
         # language = SQL
         query_str = '''
-            MATCH (n:Record)
-            RETURN COLLECT(DISTINCT n.log) AS logs
+            MATCH (l:Log)
+            RETURN COLLECT(DISTINCT l.name) AS logs
         '''
 
         return Query(query_str=query_str)

--- a/src/promg/data_managers/semantic_header.py
+++ b/src/promg/data_managers/semantic_header.py
@@ -235,7 +235,7 @@ class Relationship:
 
         name = name if name is not None else self.relation_name
         rel_pattern = Template(rel_pattern_str).substitute(rel_name=name,
-                                                           rel_type=self.get_relation_type())
+                                                           rel_type=self.get_relation_types_str())
 
         # add properties if requested and there are properties defined
         if with_properties and self.properties is not None:

--- a/src/promg/facades/oced_pg.py
+++ b/src/promg/facades/oced_pg.py
@@ -59,8 +59,8 @@ class OcedPg:
 
         # only import logs that are not imported yet
         # dataset name is considered to be unique
-        already_imported_logs = self.db_manager.get_imported_logs()[0]['logs']
-        if logs is None:
+        already_imported_logs = self.db_manager.get_imported_logs()
+        if logs is None: # no logs are predefined
             logs = self.dataset_descriptions.get_files_list()
         to_be_imported_logs = [log for log in logs if log not in already_imported_logs]
 

--- a/src/promg/modules/data_importer.py
+++ b/src/promg/modules/data_importer.py
@@ -140,8 +140,6 @@ class Importer:
                                        "mapping": mapping_str
                                    })
 
-        self.connection.exec_query(di_ql.get_merge_log_nodes_query)
-
         # delete the file from the import directory
         self._delete_log_grouped_by_labels(file_name=file_name)
 

--- a/src/promg/modules/db_management.py
+++ b/src/promg/modules/db_management.py
@@ -12,7 +12,7 @@ class DBManagement:
         self.semantic_header = semantic_header
 
     @Performance.track()
-    def clear_db(self, replace=True) -> None:
+    def clear_db(self, replace=True) -> bool:
         """
         Replace or clear the entire database by a new one
 
@@ -28,7 +28,8 @@ class DBManagement:
                 return False
         else:
             self.connection.exec_query(dbm_ql.get_delete_relationships_query)
-            return self.connection.exec_query(dbm_ql.get_delete_nodes_query)
+            self.connection.exec_query(dbm_ql.get_delete_nodes_query)
+            return True
 
     @Performance.track()
     def set_constraints(self, entity_key_name="sysId") -> None:
@@ -125,5 +126,5 @@ class DBManagement:
         print(tabulate(self.get_statistics()))
 
     def get_imported_logs(self) -> List[str]:
-        imported_logs = self.connection.exec_query(dbm_ql.get_imported_logs_query)
-        return imported_logs
+        result = self.connection.exec_query(dbm_ql.get_imported_logs_query)
+        return result[0]['logs']


### PR DESCRIPTION
There were still some minor bugs that needed to be fixed

- The `(:Log)` nodes now carry the `log` attribute instead of the `(:Record)` nodes.
- `get_convert_epoch_to_timestamp_query` had a mistake that the parameter $date_type was not passed along
- If a node was created from a relation, it can carry multiple labels. Therefore, we should request the relation types via `get_relation_types_str()` instead of `get_relation_type()`

Refactors
- Remove redundant code (`(:Log)` nodes don't have to be merged anymore)
- Ensure that the `get_imported_logs()` and `clear_db()` return the correct object as specified by the typehints