### PR TITLE
Bugfix/remove driver as context

### DIFF
--- a/src/promg/database_managers/db_connection.py
+++ b/src/promg/database_managers/db_connection.py
@@ -1,7 +1,5 @@
 from string import Template
 from typing import Optional, List, Dict, Any, Tuple
-import traceback
-from datetime import datetime
 
 import neo4j
 from ..utilities.configuration import Configuration

--- a/version.md
+++ b/version.md
@@ -1,1 +1,1 @@
-# version 2.2.0
+# version 2.2.1


### PR DESCRIPTION
The driver used as cotnext significantly slowed the code.
So, now we just use driver as a data object